### PR TITLE
Make sure polling results are only sent to instructors

### DIFF
--- a/server/src/controllers/pollController.ts
+++ b/server/src/controllers/pollController.ts
@@ -3,8 +3,9 @@ import { PollModel, StudentModel } from '../db/mogoose'
 import { io } from '../socket'
 import { client } from '../redis'
 import { customAlphabet } from 'nanoid/async'
-import { pollResult } from './socketController'
+import { pollResult, getRoomById } from './socketController'
 import { AggregatedStudent } from '../types/pollController.types'
+import { UserType } from '../types/user.types'
 const nanoid = customAlphabet('QWERTYUIOPASDFGHJKLZXCVBNM', 6)
 
 // set poll code expiry to 1 day
@@ -42,7 +43,7 @@ async function changePollStatus (pollId: string, hasStarted: boolean) {
       EX: expiry
     })
     const result = await pollResult(pollId, newSequence)
-    io.to('instructor-' + pollId).emit('result', result)
+    io.to(getRoomById(pollId, UserType.INSTRUCTOR)).emit('result', result)
   } else {
     // for every stop make the current counter negative to indicate that it is not an active sequence
     if (currSequence != null) {

--- a/server/src/controllers/pollController.ts
+++ b/server/src/controllers/pollController.ts
@@ -42,7 +42,7 @@ async function changePollStatus (pollId: string, hasStarted: boolean) {
       EX: expiry
     })
     const result = await pollResult(pollId, newSequence)
-    io.to(pollId).emit('result', result)
+    io.to('instructor-' + pollId).emit('result', result)
   } else {
     // for every stop make the current counter negative to indicate that it is not an active sequence
     if (currSequence != null) {

--- a/server/src/controllers/socketController.ts
+++ b/server/src/controllers/socketController.ts
@@ -21,6 +21,8 @@ async function join (socket: Socket, pollCode: string) {
       currSequence == null ? false : parseInt(currSequence) > 0
     console.log('Has Started', hasStarted)
     socket.join(pollId)
+    // allow targeting specific user types
+    socket.join(socket.data.userType + '-' + pollId)
     socket.data.pollId = pollId
     io.to(socket.id).emit('pollStarted', hasStarted)
   } catch (err) {
@@ -82,7 +84,7 @@ async function vote (socket: Socket, answer: number, utorid: string) {
       { upsert: true }
     )
     pollResult(pollId, parseInt(currSequence)).then((data) => {
-      io.to(pollId).emit('result', data)
+      io.to('instructor-' + pollId).emit('result', data)
     })
     io.to(socket.id).emit('ack', answer)
     return

--- a/server/src/controllers/userController.ts
+++ b/server/src/controllers/userController.ts
@@ -1,9 +1,13 @@
+import { UserType } from '../types/user.types'
 import { client } from '../redis'
 
-async function getUser (utorid: string) {
+async function getUser (utorid: string): Promise<{ status: number; data: {
+  message?: string,
+  userType?: UserType
+}}> {
   if (utorid.trim().length === 0) { return { status: 400, data: { message: 'Invalid utorid' } } }
-  let userType = await client.get(utorid)
-  if (userType == null) userType = 'student'
+  let userType = await client.get(utorid) as UserType
+  if (userType == null) userType = UserType.STUDENT
   return { status: 200, data: { userType } }
 }
 

--- a/server/src/redis.ts
+++ b/server/src/redis.ts
@@ -2,6 +2,7 @@ import { createClient } from 'redis'
 import fs from 'fs'
 import path from 'path'
 import readline from 'readline'
+import { UserType } from './types/user.types'
 
 const client = createClient({
   url: process.env.REDIS_URL
@@ -24,7 +25,7 @@ async function connectRedis () {
 
   for await (const line of rl) {
     console.log(line.trim())
-    client.set(line.trim(), 'instructor')
+    client.set(line.trim(), UserType.INSTRUCTOR)
   }
 }
 

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -62,4 +62,9 @@ const server = app.listen(port, () => {
       next(new Error('Not Authorized'))
     }
   })
+  io.use(async (socket, next) => {
+    const userType = await getUser(socket.data.utorid)
+    socket.data.userType = userType.data.userType
+    next()
+  })
 })

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -9,6 +9,7 @@ import pollRouter from './routes/pollRoute'
 import { connectMongo } from './db/mogoose'
 import userRouter from './routes/userRoutes'
 import { getUser } from './controllers/userController'
+import { UserType } from './types/user.types'
 import { connectRedis } from './redis'
 dotenv.config()
 
@@ -34,7 +35,7 @@ app.use(async (req, res, next) => {
       return next(new Error('Invalid utorid'))
     }
     const userType = await getUser(req.headers.utorid)
-    if (userType.data.userType === 'instructor') next()
+    if (userType.data.userType === UserType.INSTRUCTOR) next()
     else next(new Error('Forbidden User'))
   } catch (err) {
     next(new Error('Forbidden User'))

--- a/server/src/types/user.types.ts
+++ b/server/src/types/user.types.ts
@@ -1,0 +1,4 @@
+export enum UserType {
+    INSTRUCTOR = 'instructor',
+    STUDENT = 'student'
+}


### PR DESCRIPTION
As discovered while testing the fix for #50, add socket.io rooms for each user type, and ensure that `result` messages are only sent to the instructor room.

The user type is fetched once on socket connection and then cached, which means this approach should not add additional load to each vote.

